### PR TITLE
要素の隙間をcssで当てる

### DIFF
--- a/anime/anime_top.html
+++ b/anime/anime_top.html
@@ -11,6 +11,11 @@
         }
     </style>
 
+    <style>
+        .card-deck .card {
+            margin-bottom: 15px;
+        }
+    </style>
     <title>Document</title>
 </head>
 <body class="light_pink">
@@ -47,7 +52,7 @@
                 <p class="card-text"></p>
             </div>
         </a>
-    </div><br><br>
+    </div>
 
     <div class="card-deck">
         <a href="http://hinakonote.jp/" class="card">
@@ -78,7 +83,7 @@
                 <p class="card-text"></p>
             </div>
         </a>
-    </div><br><br>
+    </div>
 
     <div class="card-deck">
         <a href="http://koiastv.com/" class="card">
@@ -109,7 +114,7 @@
                 <p class="card-text"></p>
             </div>
         </a>
-    </div><br><br>
+    </div>
 
     <div class="card-deck">
         <a href="https://slow-start.com/" class="card">
@@ -140,7 +145,7 @@
                 <p class="card-text"></p>
             </div>
         </a>
-    </div><br><br>
+    </div>
 
     <div class="card-deck">
         <a href="https://dumbbell-anime.jp/" class="card">
@@ -171,7 +176,7 @@
                 <p class="card-text"></p>
             </div>
         </a>
-    </div><br><br>
+    </div>
 
     <div class="card-deck">
         <a href="https://yuruyuri.com/10th/" class="card">
@@ -202,7 +207,7 @@
                 <p class="card-text"></p>
             </div>
         </a>
-    </div><br><br>
+    </div>
 
     <div class="card-deck">
         <a href="https://www.ten-sura.com/" class="card">
@@ -233,7 +238,7 @@
                 <p class="card-text"></p>
             </div>
         </a>
-    </div><br><br>
+    </div>
 
     <div class="card-deck">
         <a href="http://kyuketsukisan-anime.com/" class="card">
@@ -264,7 +269,7 @@
                 <p class="card-text"></p>
             </div>
         </a>
-    </div><br><br>
+    </div>
 
     <div class="card-deck">
         <a href="https://psycho-pass.com/archive/" class="card">
@@ -295,7 +300,7 @@
                 <p class="card-text"></p>
             </div>
         </a>
-    </div><br><br>
+    </div>
 
     <div class="card-deck">
         <a href="http://www.kyotoanimation.co.jp/haruhi/" class="card">
@@ -326,7 +331,7 @@
                 <p class="card-text"></p>
             </div>
         </a>
-    </div><br><br>
+    </div>
 
     <div class="card-deck">
         <a href="https://hataraku-saibou.com/" class="card">
@@ -357,7 +362,7 @@
                 <p class="card-text"></p>
             </div>
         </a>
-    </div><br><br>
+    </div>
 
     <div class="card-deck">
         <a href="http://gabdro.com/" class="card">
@@ -388,7 +393,7 @@
                 <p class="card-text"></p>
             </div>
         </a>
-    </div><br><br>
+    </div>
 
     <div class="card-deck">
         <a href="http://yorimoi.com/" class="card">
@@ -419,7 +424,7 @@
                 <p class="card-text"></p>
             </div>
         </a>
-    </div><br><br>
+    </div>
 
     <div class="card-deck">
         <a href="http://yuyuyu.tv/" class="card">
@@ -450,7 +455,7 @@
                 <p class="card-text"></p>
             </div>
         </a>
-    </div><br><br>
+    </div>
     </div>
 
     <script type="text/javascript" src="../js/jquery.js"></script>

--- a/anime/anime_top.html
+++ b/anime/anime_top.html
@@ -11,11 +11,7 @@
         }
     </style>
 
-    <style>
-        .card-deck .card {
-            margin-bottom: 15px;
-        }
-    </style>
+    <link rel="stylesheet" href="../css/space.css">
     <title>Document</title>
 </head>
 <body class="light_pink">

--- a/comics/comic_top.html
+++ b/comics/comic_top.html
@@ -15,11 +15,11 @@
         }
     </style>
 
+    <link rel="stylesheet" href="../css/space.css">
     <title>Document</title>
 </head>
 <body class="light_pink">
-    <br><br>
-    <div class="w-50 mx-auto">
+    <div class="w-50 mx-auto link_box_padding">
     <div class="card">
     <div class="light_green">
     <div class="text-center">
@@ -29,7 +29,7 @@
     </div>
     </div>
     </div> 
-    </div><br><br>
+    </div>
 
     <div id="kirara"></div>
     <div class="w-75 mx-auto">
@@ -63,7 +63,7 @@
                 <p class="card-text">得能正太郎</p>
             </div>
         </a>
-    </div><br><br>
+    </div>
 
     <div class="card-deck">
         <a href="#" class="card">
@@ -94,7 +94,7 @@
                 <p class="card-text">篤見唯子</p>
             </div>
         </a>
-    </div><br><br>
+    </div>
 
     <div class="card-deck">
         <a href="#" class="card">
@@ -125,7 +125,7 @@
                 <p class="card-text">きゆずきさとこ</p>
             </div>
         </a>
-    </div><br><br>
+    </div>
 
     <div class="card-deck">
         <a href="#" class="card">
@@ -156,7 +156,7 @@
                 <p class="card-text">大沖</p>
             </div>
         </a>
-    </div><br><br>
+    </div>
 
     <div class="card-deck">
         <a href="#" class="card">
@@ -187,7 +187,7 @@
                 <p class="card-text">海老川ケイ</p>
             </div>
         </a>
-    </div><br><br>
+    </div>
 
     <div class="card-deck">
         <a href="#" class="card">
@@ -218,7 +218,7 @@
                 <p class="card-text">あfろ</p>
             </div>
         </a>
-    </div><br><br>
+    </div>
 
     <div class="card-deck">
         <a href="#" class="card">
@@ -249,7 +249,7 @@
                 <p class="card-text">相崎うたう</p>
             </div>
         </a>
-    </div><br><br>
+    </div>
 
     <div class="card-deck">
         <a href="#" class="card">
@@ -280,7 +280,7 @@
                 <p class="card-text">かきふらい</p>
             </div>
         </a>
-    </div><br><br>
+    </div>
 
     <div class="card-deck">
         <a href="#" class="card">
@@ -311,7 +311,7 @@
                 <p class="card-text">浜弓場双</p>
             </div>
         </a>
-    </div><br><br>
+    </div>
 
     <div class="card-deck">
         <a href="#" class="card">
@@ -342,7 +342,7 @@
                 <p class="card-text">双見酔</p>
             </div>
         </a>
-    </div><br><br>
+    </div>
 
     <div class="card-deck">
         <a href="#" class="card">
@@ -373,7 +373,7 @@
                 <p class="card-text"></p>
             </div>
         </div>
-    </div><br><br>
+    </div>
 
 
     <div id="others"></div>
@@ -407,7 +407,7 @@
                 <p class="card-text">椋木ななつ</p>
             </div>
         </a>
-    </div><br><br>
+    </div>
 
     <div class="card-deck">
         <a href="#" class="card">
@@ -438,7 +438,7 @@
                 <p class="card-text">甘党</p>
             </div>
         </a>
-    </div><br><br>
+    </div>
 
     <div class="card-deck">
         <a href="#" class="card">
@@ -469,7 +469,7 @@
                 <p class="card-text">リムコロ</p>
             </div>
         </a>
-    </div><br><br>
+    </div>
 
     <div class="card-deck">
         <a href="#" class="card">
@@ -500,7 +500,7 @@
                 <p class="card-text"></p>
             </div>
         </div>
-    </div><br><br>
+    </div>
 
 
     </div>

--- a/css/space.css
+++ b/css/space.css
@@ -1,0 +1,6 @@
+.card-deck .card {
+    margin-bottom: 15px;
+}
+.link_box_padding{
+    padding: 20px 0px 20px;
+}

--- a/paint/paint_top.html
+++ b/paint/paint_top.html
@@ -11,11 +11,12 @@
         }
     </style>
 
+    <link rel="stylesheet" href="../css/space.css">
     <title>Document</title>
 </head>
 <body class="light_pink">
-    <br><br>
-    <div class="w-50 mx-auto">
+    
+    <div class="w-50 mx-auto link_box_padding">
         <div class="card">
         <div class="light_green">
         <div class="text-center">
@@ -25,7 +26,7 @@
         </div>
         </div>
         </div> 
-        </div><br><br>
+        </div>
 
     <div class="w-75 mx-auto">
     <div id="illustration"></div>
@@ -59,7 +60,7 @@
                 <p class="card-text">東方Project</p>
             </div>
         </a>
-    </div><br><br>
+    </div>
 
     <div class="card-deck">
         <a href="https://www.pixiv.net/artworks/83199292" class="card">
@@ -90,7 +91,7 @@
                 <p class="card-text">虚構推理</p>
             </div>
         </a>
-    </div><br><br>
+    </div>
 
     <div class="card-deck">
         <a href="https://www.pixiv.net/artworks/80012966" class="card">
@@ -121,7 +122,7 @@
                 <p class="card-text">アニマエール！</p>
             </div>
         </a>
-    </div><br><br>
+    </div>
 
     <div class="card-deck">
         <a href="https://www.pixiv.net/artworks/79205962" class="card">
@@ -152,7 +153,7 @@
                 <p class="card-text">Bang' Dream!</p>
             </div>
         </a>
-    </div><br><br>
+    </div>
 
     <div class="card-deck">
         <a href="https://www.pixiv.net/artworks/78991019" class="card">
@@ -183,7 +184,7 @@
                 <p class="card-text">世話やきキツネの仙狐さん</p>
             </div>
         </a>
-    </div><br><br>
+    </div>
 
     <div class="card-deck">
         <a href="https://www.pixiv.net/artworks/75156962" class="card">
@@ -214,7 +215,7 @@
                 <p class="card-text">東方Project</p>
             </div>
         </a>
-    </div><br><br>
+    </div>
 
     <div class="card-deck">
         <a href="https://www.pixiv.net/artworks/69035005" class="card">
@@ -245,7 +246,7 @@
                 <p class="card-text">東方Project</p>
             </div>
         </a>
-    </div><br><br>
+    </div>
 
     <div id="comic"></div>
     <h3>二次創作　漫画</h3>
@@ -279,7 +280,7 @@
                 <p class="card-text">Bang' Dream!</p>
             </div>
         </a>
-    </div><br><br>
+    </div>
 
 
     </div>


### PR DESCRIPTION
### やったこと
```
space.css
```
に隙間を開けるスタイルを記入しました。
`<br>`で隙間をあけていましたが、`space.css`をよみこみclassをあてることで隙間を開けました。

### これをやっていいこと
モバイルで表示したときもきちんと隙間を開けられるようになります。